### PR TITLE
EP entries for plugin-overridestyle.dita

### DIFF
--- a/topics/plugin-overridestyle.dita
+++ b/topics/plugin-overridestyle.dita
@@ -9,7 +9,9 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>plugin</indexterm>
+        <indexterm>XSL-override</indexterm>
+        <indexterm>XSLT</indexterm>
       </keywords>
     </metadata>
   </prolog>


### PR DESCRIPTION
PR #124 to #128 did not include the changes for `plugin-overridestyle.dita` on the `cos17-indexing-patch-3` branch, so this PR adds those.