### PR TITLE
Cos17 joschak redux2

### DIFF
--- a/parameters/internal-ant-properties.dita
+++ b/parameters/internal-ant-properties.dita
@@ -8,7 +8,9 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>Internal Ant properties</indexterm>
+        <indexterm>ink roles</indexterm>
+        <indexterm>custom transform types</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/extending-the-ot.dita
+++ b/topics/extending-the-ot.dita
@@ -13,7 +13,11 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>DITA-OT extensions</indexterm>
+        <indexterm>custom stylesheets</indexterm>
+        <indexterm>DITA-OT plugins</indexterm>
+        <indexterm>customizing output</indexterm>
+        <indexterm>globalizing DITA content</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/html-customization-css.dita
+++ b/topics/html-customization-css.dita
@@ -10,7 +10,9 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>custom HTML</indexterm>
+        <indexterm>HTML parameters</indexterm>
+        <indexterm>custom CSS</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/html-customization-navigation.dita
+++ b/topics/html-customization-navigation.dita
@@ -13,7 +13,9 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>custom HTML</indexterm>
+        <indexterm>HTML parameters</indexterm>
+        <indexterm>add navigation</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/html-customization-parameters.dita
+++ b/topics/html-customization-parameters.dita
@@ -13,7 +13,8 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>custom HTML</indexterm>
+        <indexterm>HTML parameters</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/html-customization.dita
+++ b/topics/html-customization.dita
@@ -12,7 +12,9 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm></indexterm>
+        <indexterm>custom HTML</indexterm>
+        <indexterm>HTML parameters</indexterm>
+        <indexterm>.properties file, to customize HTML</indexterm>
       </keywords>
     </metadata>
   </prolog>


### PR DESCRIPTION
This PR supersedes #90 to include the changes from the `cos17-indexing-patch-6` branch and also picks up the changes from 3778721635e3a22f82ce7d961b2c1eef96ed1b8d, which were missing in #90.

(Looks like the changes in joschak/dita-ot-docs@88a48d1 were mistakenly applied to the wrong file, which conflicted with the changes in joschak/dita-ot-docs@a146dc6.)

c9bd3a3 re-applies those changes to the proper file to replicate the original intent.